### PR TITLE
Moved GitHub orgs from bwNetFlow to BelWue

### DIFF
--- a/cmd/explain/main.go
+++ b/cmd/explain/main.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/bwNetFlow/flowfilter/parser"
-	"github.com/bwNetFlow/flowfilter/visitors"
+	"github.com/BelWue/flowfilter/parser"
+	"github.com/BelWue/flowfilter/visitors"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bwNetFlow/flowfilter
+module github.com/BelWue/flowfilter
 
 go 1.18
 

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 github.com/alecthomas/assert/v2 v2.0.3 h1:WKqJODfOiQG0nEJKFKzDIG3E29CN2/4zR9XGJzKIkbg=
 github.com/alecthomas/participle/v2 v2.0.0-beta.1 h1:qA1IALv09wFD4fQ2anV6MCl1BIInd+Dm+ksI6ES4kfs=
 github.com/alecthomas/participle/v2 v2.0.0-beta.1/go.mod h1:RC764t6n4L8D8ITAJv0qdokritYSNR3wV5cVwmIEaMM=
-github.com/alecthomas/participle/v2 v2.0.0-beta.5 h1:y6dsSYVb1G5eK6mgmy+BgI3Mw35a3WghArZ/Hbebrjo=
-github.com/alecthomas/participle/v2 v2.0.0-beta.5/go.mod h1:RC764t6n4L8D8ITAJv0qdokritYSNR3wV5cVwmIEaMM=
 github.com/alecthomas/repr v0.1.0 h1:ENn2e1+J3k09gyj2shc0dHr/yjaWSHRlrJ4DPMevDqE=
 github.com/bwNetFlow/flowpipeline v0.9.3-beta h1:0WcPBteAxL8JcywAt0j8IBCTX9+egrz4s/zd4n4ZL84=
 github.com/bwNetFlow/flowpipeline v0.9.3-beta/go.mod h1:GdtC6jnkQm1p9yCseR4VfThb0jMZi8UAV+b51J2LhYM=

--- a/visitors/flowfilter.go
+++ b/visitors/flowfilter.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"strings"
 
-	"github.com/bwNetFlow/flowfilter/parser"
+	"github.com/BelWue/flowfilter/parser"
 	"github.com/bwNetFlow/flowpipeline/pb"
 )
 

--- a/visitors/flowfilter_test.go
+++ b/visitors/flowfilter_test.go
@@ -5,7 +5,7 @@ import (
 	// "net"
 	"testing"
 
-	"github.com/bwNetFlow/flowfilter/parser"
+	"github.com/BelWue/flowfilter/parser"
 	"github.com/bwNetFlow/flowpipeline/pb"
 )
 

--- a/visitors/noop.go
+++ b/visitors/noop.go
@@ -3,7 +3,7 @@ package visitors
 import (
 	"fmt"
 
-	"github.com/bwNetFlow/flowfilter/parser"
+	"github.com/BelWue/flowfilter/parser"
 )
 
 type Noop struct {

--- a/visitors/printer.go
+++ b/visitors/printer.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	// "github.com/alecthomas/repr"
-	"github.com/bwNetFlow/flowfilter/parser"
+	"github.com/BelWue/flowfilter/parser"
 )
 
 type Printer struct {


### PR DESCRIPTION
Fixes module names, etc., since the project was moved from bwNetFlow to the BelWü organization.